### PR TITLE
feat: prune workflow autosave versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ dependencies {
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testImplementation 'org.springframework.security:spring-security-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/phong/zenflow/ZenflowApplication.java
+++ b/src/main/java/org/phong/zenflow/ZenflowApplication.java
@@ -2,8 +2,10 @@ package org.phong.zenflow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ZenflowApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/phong/zenflow/workflow/service/WorkflowService.java
+++ b/src/main/java/org/phong/zenflow/workflow/service/WorkflowService.java
@@ -17,6 +17,7 @@ import org.phong.zenflow.workflow.infrastructure.persistence.entity.Workflow;
 import org.phong.zenflow.workflow.infrastructure.persistence.repository.WorkflowRepository;
 import org.phong.zenflow.workflow.subdomain.node_definition.definitions.WorkflowDefinition;
 import org.phong.zenflow.workflow.subdomain.node_definition.services.WorkflowDefinitionService;
+import org.phong.zenflow.workflow.subdomain.workflow_version.service.WorkflowVersionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,7 @@ public class WorkflowService {
     private final ProjectRepository projectRepository;
     private final WorkflowMapper workflowMapper;
     private final WorkflowDefinitionService definitionService;
+    private final WorkflowVersionService workflowVersionService;
 
     /**
      * Create a new workflow
@@ -89,6 +91,9 @@ public class WorkflowService {
 
         workflow.setDefinition(upserted);
         workflowRepository.save(workflow);
+
+        // Auto save workflow definition as a version
+        workflowVersionService.autoSave(workflowId, upserted);
 
         return upserted;
     }

--- a/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/controller/WorkflowVersionController.java
+++ b/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/controller/WorkflowVersionController.java
@@ -1,0 +1,48 @@
+package org.phong.zenflow.workflow.subdomain.workflow_version.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.phong.zenflow.core.responses.RestApiResponse;
+import org.phong.zenflow.workflow.subdomain.workflow_version.dto.WorkflowVersionDto;
+import org.phong.zenflow.workflow.subdomain.workflow_version.service.WorkflowVersionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/workflows/{workflowId}/versions")
+@RequiredArgsConstructor
+public class WorkflowVersionController {
+
+    private final WorkflowVersionService workflowVersionService;
+
+    @GetMapping
+    public ResponseEntity<RestApiResponse<List<WorkflowVersionDto>>> getVersions(@PathVariable UUID workflowId) {
+        List<WorkflowVersionDto> versions = workflowVersionService.getVersions(workflowId);
+        return RestApiResponse.success(versions, "Workflow versions retrieved successfully");
+    }
+
+    @GetMapping("/{version}")
+    public ResponseEntity<RestApiResponse<WorkflowVersionDto>> getVersion(
+            @PathVariable UUID workflowId,
+            @PathVariable Integer version) {
+        WorkflowVersionDto versionDto = workflowVersionService.getVersion(workflowId, version);
+        return RestApiResponse.success(versionDto, "Workflow version retrieved successfully");
+    }
+
+    @DeleteMapping("/{version}")
+    public ResponseEntity<RestApiResponse<Void>> deleteVersion(
+            @PathVariable UUID workflowId,
+            @PathVariable Integer version) {
+        workflowVersionService.deleteVersion(workflowId, version);
+        return RestApiResponse.noContent();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<RestApiResponse<Void>> deleteAllVersions(@PathVariable UUID workflowId) {
+        workflowVersionService.deleteAllVersions(workflowId);
+        return RestApiResponse.noContent();
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/dto/WorkflowVersionDto.java
+++ b/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/dto/WorkflowVersionDto.java
@@ -1,0 +1,24 @@
+package org.phong.zenflow.workflow.subdomain.workflow_version.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.WorkflowDefinition;
+
+/**
+ * DTO for {@link org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.entity.WorkflowVersion}
+ */
+public record WorkflowVersionDto(
+        @NotNull UUID id,
+        @NotNull UUID workflowId,
+        @NotNull Integer version,
+        WorkflowDefinition definition,
+        Boolean isAutosave,
+        UUID createdBy,
+        @NotNull OffsetDateTime createdAt
+) implements Serializable {
+}
+

--- a/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/infrastructure/mapstruct/WorkflowVersionMapper.java
+++ b/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/infrastructure/mapstruct/WorkflowVersionMapper.java
@@ -1,0 +1,20 @@
+package org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.mapstruct;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+import org.phong.zenflow.workflow.subdomain.workflow_version.dto.WorkflowVersionDto;
+import org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.entity.WorkflowVersion;
+
+import java.util.List;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = MappingConstants.ComponentModel.SPRING)
+public interface WorkflowVersionMapper {
+
+    @Mapping(source = "workflow.id", target = "workflowId")
+    WorkflowVersionDto toDto(WorkflowVersion workflowVersion);
+
+    List<WorkflowVersionDto> toDtoList(List<WorkflowVersion> versions);
+}
+

--- a/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/infrastructure/persistence/entity/WorkflowVersion.java
+++ b/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/infrastructure/persistence/entity/WorkflowVersion.java
@@ -1,0 +1,71 @@
+package org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.entity;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import org.hibernate.annotations.ColumnDefault;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.phong.zenflow.core.superbase.BaseIdEntity;
+import org.phong.zenflow.workflow.infrastructure.persistence.entity.Workflow;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.WorkflowDefinition;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "workflow_versions",
+        indexes = {@Index(name = "idx_workflow_versions_workflow_id", columnList = "workflow_id")},
+        uniqueConstraints = {@UniqueConstraint(name = "uk_workflow_version", columnNames = {"workflow_id", "version"})})
+@AttributeOverrides({
+        @AttributeOverride(name = "id", column = @Column(name = "id", nullable = false))
+})
+public class WorkflowVersion extends BaseIdEntity {
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "workflow_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Workflow workflow;
+
+    @NotNull
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Column(name = "definition")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private WorkflowDefinition definition;
+
+    @NotNull
+    @ColumnDefault("false")
+    @Column(name = "is_autosave", nullable = false)
+    private Boolean isAutosave = false;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @NotNull
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/infrastructure/persistence/repository/WorkflowVersionRepository.java
+++ b/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/infrastructure/persistence/repository/WorkflowVersionRepository.java
@@ -1,0 +1,30 @@
+package org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.repository;
+
+import org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.entity.WorkflowVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface WorkflowVersionRepository extends JpaRepository<WorkflowVersion, UUID> {
+    Optional<WorkflowVersion> findTopByWorkflow_IdOrderByVersionDesc(UUID workflowId);
+
+    List<WorkflowVersion> findByWorkflow_IdOrderByVersionDesc(UUID workflowId);
+
+    Optional<WorkflowVersion> findByWorkflow_IdAndVersion(UUID workflowId, Integer version);
+
+    @Modifying
+    void deleteByWorkflow_IdAndCreatedAtBefore(UUID workflowId, OffsetDateTime createdAt);
+
+    @Modifying
+    void deleteByWorkflow_IdAndVersion(UUID workflowId, Integer version);
+
+    @Modifying
+    void deleteByWorkflow_Id(UUID workflowId);
+}
+

--- a/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/service/WorkflowVersionService.java
+++ b/src/main/java/org/phong/zenflow/workflow/subdomain/workflow_version/service/WorkflowVersionService.java
@@ -1,0 +1,115 @@
+package org.phong.zenflow.workflow.subdomain.workflow_version.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.workflow.exception.WorkflowException;
+import org.phong.zenflow.workflow.infrastructure.persistence.entity.Workflow;
+import org.phong.zenflow.workflow.infrastructure.persistence.repository.WorkflowRepository;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.WorkflowDefinition;
+import org.phong.zenflow.workflow.subdomain.workflow_version.dto.WorkflowVersionDto;
+import org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.mapstruct.WorkflowVersionMapper;
+import org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.entity.WorkflowVersion;
+import org.phong.zenflow.workflow.subdomain.workflow_version.infrastructure.persistence.repository.WorkflowVersionRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class WorkflowVersionService {
+
+    private final WorkflowVersionRepository versionRepository;
+    private final WorkflowRepository workflowRepository;
+    private final WorkflowVersionMapper versionMapper;
+
+    private static final long CACHE_TTL_MS = 5000L;
+    private static final int MAX_VERSIONS = 25;
+    private static final int RETENTION_DAYS = 3;
+
+    private final Map<UUID, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    @Transactional
+    public void autoSave(UUID workflowId, WorkflowDefinition definition) {
+        String hash = definition != null ? String.valueOf(definition.hashCode()) : "null";
+        long now = System.currentTimeMillis();
+
+        CacheEntry entry = cache.get(workflowId);
+        if (entry != null && entry.hash().equals(hash) && now - entry.timestamp() < CACHE_TTL_MS) {
+            return; // Recently saved same content
+        }
+
+        Optional<WorkflowVersion> latestOpt = versionRepository.findTopByWorkflow_IdOrderByVersionDesc(workflowId);
+        if (latestOpt.isPresent()) {
+            WorkflowVersion latest = latestOpt.get();
+            String latestHash = latest.getDefinition() != null ? String.valueOf(latest.getDefinition().hashCode()) : "null";
+            if (latestHash.equals(hash)) {
+                cache.put(workflowId, new CacheEntry(hash, now));
+                return; // No change compared to latest version
+            }
+        }
+
+        cache.put(workflowId, new CacheEntry(hash, now));
+
+        Workflow workflowRef = workflowRepository.getReferenceById(workflowId);
+        int nextVersion = latestOpt.map(v -> v.getVersion() + 1).orElse(1);
+
+        WorkflowVersion version = new WorkflowVersion();
+        version.setWorkflow(workflowRef);
+        version.setVersion(nextVersion);
+        version.setDefinition(definition);
+        version.setIsAutosave(true);
+
+        versionRepository.save(version);
+    }
+
+    private record CacheEntry(String hash, long timestamp) {
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void cleanupAllVersions() {
+        workflowRepository.findAll().forEach(w -> cleanupVersions(w.getId()));
+    }
+
+    private void cleanupVersions(UUID workflowId) {
+        OffsetDateTime threshold = OffsetDateTime.now().minusDays(RETENTION_DAYS);
+        versionRepository.deleteByWorkflow_IdAndCreatedAtBefore(workflowId, threshold);
+
+        List<WorkflowVersion> versions = versionRepository.findByWorkflow_IdOrderByVersionDesc(workflowId);
+        if (versions.size() > MAX_VERSIONS) {
+            versionRepository.deleteAll(versions.subList(MAX_VERSIONS, versions.size()));
+        }
+    }
+
+    public List<WorkflowVersionDto> getVersions(UUID workflowId) {
+        return versionMapper.toDtoList(versionRepository.findByWorkflow_IdOrderByVersionDesc(workflowId));
+    }
+
+    public WorkflowVersionDto getVersion(UUID workflowId, Integer version) {
+        return versionRepository.findByWorkflow_IdAndVersion(workflowId, version)
+                .map(versionMapper::toDto)
+                .orElseThrow(() -> new WorkflowException("Workflow version not found"));
+    }
+
+    @Transactional
+    public void deleteVersion(UUID workflowId, Integer version) {
+        WorkflowVersion existing = versionRepository.findByWorkflow_IdAndVersion(workflowId, version)
+                .orElseThrow(() -> new WorkflowException("Workflow version not found"));
+        versionRepository.delete(existing);
+    }
+
+    @Transactional
+    public void deleteAllVersions(UUID workflowId) {
+        versionRepository.deleteByWorkflow_Id(workflowId);
+    }
+}
+


### PR DESCRIPTION
## Summary
- purge workflow versions beyond 25 entries or older than three days on scheduled cleanup
- cache recent workflow definitions to avoid duplicate version writes
- enable scheduling and drop ad-hoc test configuration
- add manual workflow version retrieval and deletion endpoints

## Testing
- `sh gradlew test --no-daemon` *(fails: ZenflowApplicationTests > contextLoads)*

------
https://chatgpt.com/codex/tasks/task_b_6896113b3534832dbbb2df4c60052e03