### PR TITLE
feat: split group and aggregation transformers

### DIFF
--- a/src/main/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/AggregateTransformer.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/AggregateTransformer.java
@@ -1,0 +1,183 @@
+package org.phong.zenflow.plugin.subdomain.executors.builtin.data.data_transformer.impl.aggregation;
+
+import org.phong.zenflow.plugin.subdomain.executors.builtin.data.data_transformer.exception.DataTransformerExecutorException;
+import org.phong.zenflow.plugin.subdomain.executors.builtin.data.data_transformer.interfaces.DataTransformer;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Applies aggregation functions on grouped data produced by {@link GroupByTransformer}.
+ */
+@Component
+public class AggregateTransformer implements DataTransformer {
+
+    @Override
+    public String getName() {
+        return "aggregate";
+    }
+
+    @Override
+    public Object transform(Object data, Map<String, Object> params) {
+        if (!(data instanceof List<?> groups)) {
+            throw new DataTransformerExecutorException("Input must be a List for aggregate transformer.");
+        }
+
+        if (params == null || !params.containsKey("aggregations")) {
+            throw new DataTransformerExecutorException("aggregations parameter is required for aggregate transformer.");
+        }
+
+        List<Map<String, Object>> aggregations = extractAggregations(params);
+        List<Map<String, Object>> results = new ArrayList<>();
+
+        for (Object groupObj : groups) {
+            if (!(groupObj instanceof Map<?, ?> groupMap)) {
+                throw new DataTransformerExecutorException("Each group must be a Map for aggregate transformer.");
+            }
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> items = (List<Map<String, Object>>) groupMap.get("items");
+            if (items == null) {
+                throw new DataTransformerExecutorException("Group missing 'items' list for aggregate transformer.");
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> result = new HashMap<>((Map<String, Object>) groupMap);
+            result.remove("items");
+
+            for (Map<String, Object> aggregation : aggregations) {
+                String field = (String) aggregation.get("field");
+                String function = (String) aggregation.get("function");
+                String alias = (String) aggregation.getOrDefault("alias", field + "_" + function);
+
+                Object aggregatedValue = applyAggregation(items, field, function);
+                result.put(alias, aggregatedValue);
+            }
+
+            results.add(result);
+        }
+
+        return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> extractAggregations(Map<String, Object> params) {
+        Object aggregationsObj = params.get("aggregations");
+        if (aggregationsObj == null) {
+            return Collections.emptyList();
+        }
+
+        if (aggregationsObj instanceof List<?> list) {
+            return list.stream()
+                    .map(item -> (Map<String, Object>) item)
+                    .collect(Collectors.toList());
+        }
+
+        throw new DataTransformerExecutorException("aggregations must be a list of aggregation objects.");
+    }
+
+    private Object applyAggregation(List<Map<String, Object>> items, String field, String function) {
+        return switch (function.toLowerCase()) {
+            case "count" -> items.size();
+            case "sum" -> calculateSum(items, field);
+            case "avg", "average" -> calculateAverage(items, field);
+            case "min" -> calculateMin(items, field);
+            case "max" -> calculateMax(items, field);
+            case "first" -> getFirst(items, field);
+            case "last" -> getLast(items, field);
+            case "concat" -> concatenateValues(items, field);
+            case "distinct_count" -> countDistinct(items, field);
+            case "std_dev" -> calculateStandardDeviation(items, field);
+            default -> throw new DataTransformerExecutorException("Unsupported aggregation function: " + function);
+        };
+    }
+
+    private double calculateSum(List<Map<String, Object>> items, String field) {
+        return items.stream()
+                .mapToDouble(item -> convertToDouble(item.get(field)))
+                .sum();
+    }
+
+    private double calculateAverage(List<Map<String, Object>> items, String field) {
+        return items.stream()
+                .mapToDouble(item -> convertToDouble(item.get(field)))
+                .average()
+                .orElse(0.0);
+    }
+
+    private Object calculateMin(List<Map<String, Object>> items, String field) {
+        return items.stream()
+                .map(item -> item.get(field))
+                .filter(Objects::nonNull)
+                .min(this::compareValues)
+                .orElse(null);
+    }
+
+    private Object calculateMax(List<Map<String, Object>> items, String field) {
+        return items.stream()
+                .map(item -> item.get(field))
+                .filter(Objects::nonNull)
+                .max(this::compareValues)
+                .orElse(null);
+    }
+
+    private Object getFirst(List<Map<String, Object>> items, String field) {
+        return items.isEmpty() ? null : items.getFirst().get(field);
+    }
+
+    private Object getLast(List<Map<String, Object>> items, String field) {
+        return items.isEmpty() ? null : items.getLast().get(field);
+    }
+
+    private String concatenateValues(List<Map<String, Object>> items, String field) {
+        return items.stream()
+                .map(item -> String.valueOf(item.get(field)))
+                .filter(value -> !"null".equals(value))
+                .collect(Collectors.joining(", "));
+    }
+
+    private long countDistinct(List<Map<String, Object>> items, String field) {
+        return items.stream()
+                .map(item -> item.get(field))
+                .filter(Objects::nonNull)
+                .distinct()
+                .count();
+    }
+
+    private double calculateStandardDeviation(List<Map<String, Object>> items, String field) {
+        double mean = calculateAverage(items, field);
+        double variance = items.stream()
+                .mapToDouble(item -> {
+                    double value = convertToDouble(item.get(field));
+                    return Math.pow(value - mean, 2);
+                })
+                .average()
+                .orElse(0.0);
+        return Math.sqrt(variance);
+    }
+
+    private double convertToDouble(Object value) {
+        if (value == null) return 0.0;
+        if (value instanceof Number num) return num.doubleValue();
+        try {
+            return Double.parseDouble(value.toString());
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private int compareValues(Object a, Object b) {
+        int comparison = a.toString().compareTo(b.toString());
+        if (a instanceof Comparable && b instanceof Comparable) {
+            try {
+                return ((Comparable<Object>) a).compareTo(b);
+            } catch (ClassCastException e) {
+                return comparison;
+            }
+        }
+        return comparison;
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/GroupByTransformer.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/GroupByTransformer.java
@@ -7,6 +7,12 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * Groups a list of map objects by the provided fields. This transformer no longer performs
+ * any aggregation logic. Instead, it returns a collection of groups where each group contains
+ * the grouped field values along with the list of items that belong to that group. Any
+ * aggregations should be handled by {@link AggregateTransformer}.
+ */
 @Component
 public class GroupByTransformer implements DataTransformer {
 
@@ -26,14 +32,11 @@ public class GroupByTransformer implements DataTransformer {
         }
 
         List<String> groupByFields = extractGroupByFields(params);
-        List<Map<String, Object>> aggregations = extractAggregations(params);
 
-        // Group the data
         Map<String, List<Map<String, Object>>> groups = groupData(list, groupByFields);
 
-        // Apply aggregations
         return groups.entrySet().stream()
-                .map(entry -> createAggregatedResult(entry.getKey(), entry.getValue(), groupByFields, aggregations))
+                .map(entry -> createGroupResult(entry.getKey(), entry.getValue(), groupByFields))
                 .collect(Collectors.toList());
     }
 
@@ -49,22 +52,6 @@ public class GroupByTransformer implements DataTransformer {
     }
 
     @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> extractAggregations(Map<String, Object> params) {
-        Object aggregationsObj = params.get("aggregations");
-        if (aggregationsObj == null) {
-            return Collections.emptyList();
-        }
-
-        if (aggregationsObj instanceof List<?> list) {
-            return list.stream()
-                    .map(item -> (Map<String, Object>) item)
-                    .collect(Collectors.toList());
-        }
-
-        throw new DataTransformerExecutorException("aggregations must be a list of aggregation objects.");
-    }
-
-    @SuppressWarnings("unchecked")
     private Map<String, List<Map<String, Object>>> groupData(List<?> list, List<String> groupByFields) {
         return list.stream()
                 .map(item -> (Map<String, Object>) item)
@@ -77,130 +64,17 @@ public class GroupByTransformer implements DataTransformer {
                 .collect(Collectors.joining("||"));
     }
 
-    private Map<String, Object> createAggregatedResult(String groupKey, List<Map<String, Object>> groupItems,
-                                                      List<String> groupByFields, List<Map<String, Object>> aggregations) {
+    private Map<String, Object> createGroupResult(String groupKey, List<Map<String, Object>> groupItems,
+                                                 List<String> groupByFields) {
         Map<String, Object> result = new HashMap<>();
 
-        // Add group by fields to result
         String[] keyParts = groupKey.split("\\|\\|");
         for (int i = 0; i < groupByFields.size() && i < keyParts.length; i++) {
             result.put(groupByFields.get(i), keyParts[i]);
         }
 
-        // Apply aggregations
-        for (Map<String, Object> aggregation : aggregations) {
-            String field = (String) aggregation.get("field");
-            String function = (String) aggregation.get("function");
-            String alias = (String) aggregation.getOrDefault("alias", field + "_" + function);
-
-            Object aggregatedValue = applyAggregation(groupItems, field, function);
-            result.put(alias, aggregatedValue);
-        }
-
+        result.put("items", groupItems);
         return result;
     }
-
-    private Object applyAggregation(List<Map<String, Object>> items, String field, String function) {
-        return switch (function.toLowerCase()) {
-            case "count" -> items.size();
-            case "sum" -> calculateSum(items, field);
-            case "avg", "average" -> calculateAverage(items, field);
-            case "min" -> calculateMin(items, field);
-            case "max" -> calculateMax(items, field);
-            case "first" -> getFirst(items, field);
-            case "last" -> getLast(items, field);
-            case "concat" -> concatenateValues(items, field);
-            case "distinct_count" -> countDistinct(items, field);
-            case "std_dev" -> calculateStandardDeviation(items, field);
-            default -> throw new DataTransformerExecutorException("Unsupported aggregation function: " + function);
-        };
-    }
-
-    private double calculateSum(List<Map<String, Object>> items, String field) {
-        return items.stream()
-                .mapToDouble(item -> convertToDouble(item.get(field)))
-                .sum();
-    }
-
-    private double calculateAverage(List<Map<String, Object>> items, String field) {
-        return items.stream()
-                .mapToDouble(item -> convertToDouble(item.get(field)))
-                .average()
-                .orElse(0.0);
-    }
-
-    private Object calculateMin(List<Map<String, Object>> items, String field) {
-        return items.stream()
-                .map(item -> item.get(field))
-                .filter(Objects::nonNull)
-                .min(this::compareValues)
-                .orElse(null);
-    }
-
-    private Object calculateMax(List<Map<String, Object>> items, String field) {
-        return items.stream()
-                .map(item -> item.get(field))
-                .filter(Objects::nonNull)
-                .max(this::compareValues)
-                .orElse(null);
-    }
-
-    private Object getFirst(List<Map<String, Object>> items, String field) {
-        return items.isEmpty() ? null : items.getFirst().get(field);
-    }
-
-    private Object getLast(List<Map<String, Object>> items, String field) {
-        return items.isEmpty() ? null : items.getLast().get(field);
-    }
-
-    private String concatenateValues(List<Map<String, Object>> items, String field) {
-        return items.stream()
-                .map(item -> String.valueOf(item.get(field)))
-                .filter(value -> !"null".equals(value))
-                .collect(Collectors.joining(", "));
-    }
-
-    private long countDistinct(List<Map<String, Object>> items, String field) {
-        return items.stream()
-                .map(item -> item.get(field))
-                .filter(Objects::nonNull)
-                .distinct()
-                .count();
-    }
-
-    private double calculateStandardDeviation(List<Map<String, Object>> items, String field) {
-        double mean = calculateAverage(items, field);
-        double variance = items.stream()
-                .mapToDouble(item -> {
-                    double value = convertToDouble(item.get(field));
-                    return Math.pow(value - mean, 2);
-                })
-                .average()
-                .orElse(0.0);
-        return Math.sqrt(variance);
-    }
-
-    private double convertToDouble(Object value) {
-        if (value == null) return 0.0;
-        if (value instanceof Number num) return num.doubleValue();
-        try {
-            return Double.parseDouble(value.toString());
-        } catch (NumberFormatException e) {
-            return 0.0;
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private int compareValues(Object a, Object b) {
-        int comparison = a.toString().compareTo(b.toString());
-        if (a instanceof Comparable && b instanceof Comparable) {
-            try {
-                return ((Comparable<Object>) a).compareTo(b);
-            } catch (ClassCastException e) {
-                // Fallback to string comparison
-                return comparison;
-            }
-        }
-        return comparison;
-    }
 }
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/registry/TransformerRegistry.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/registry/TransformerRegistry.java
@@ -18,6 +18,10 @@ public class TransformerRegistry {
     }
 
     public DataTransformer getTransformer(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new ExecutorException("Unknown executor type: " + name);
+        }
+
         return Optional.ofNullable(registry.get(name))
                 .orElseThrow(() -> new ExecutorException("Unknown executor type: " + name));
     }

--- a/src/main/resources/db/migration/V8__insert_default_plugin_core_nodes.sql
+++ b/src/main/resources/db/migration/V8__insert_default_plugin_core_nodes.sql
@@ -229,7 +229,7 @@ VALUES
        },
        "required": ["expression"]
      },
-     "group_by_params": {
+    "group_by_params": {
        "type": "object",
        "properties": {
          "groupBy": {
@@ -237,7 +237,13 @@ VALUES
              {"type": "string"},
              {"type": "array", "items": {"type": "string"}}
            ]
-         },
+         }
+       },
+       "required": ["groupBy"]
+     },
+     "aggregate_params": {
+       "type": "object",
+       "properties": {
          "aggregations": {
            "type": "array",
            "items": {
@@ -251,7 +257,7 @@ VALUES
            }
          }
        },
-       "required": ["groupBy"]
+       "required": ["aggregations"]
      },
      "distinct_params": {
        "type": "object",
@@ -487,6 +493,12 @@ VALUES
            "properties": {
              "transformer": {"const": "group_by"},
              "params": {"$ref": "#/definitions/group_by_params"}
+           }
+         },
+         {
+           "properties": {
+             "transformer": {"const": "aggregate"},
+             "params": {"$ref": "#/definitions/aggregate_params"}
            }
          },
          {

--- a/src/test/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/AggregateTransformerTest.java
+++ b/src/test/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/AggregateTransformerTest.java
@@ -1,0 +1,93 @@
+package org.phong.zenflow.plugin.subdomain.executors.builtin.data.data_transformer.impl.aggregation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AggregateTransformerTest {
+
+    private AggregateTransformer aggregateTransformer;
+
+    @BeforeEach
+    void setUp() {
+        aggregateTransformer = new AggregateTransformer();
+    }
+
+    @Test
+    void testTransformAggregations() {
+        List<Map<String, Object>> groups = Arrays.asList(
+                Map.of(
+                        "department", "IT",
+                        "items", Arrays.asList(
+                                Map.of("name", "John", "department", "IT", "age", 30, "salary", 50000),
+                                Map.of("name", "Bob", "department", "IT", "age", 35, "salary", 60000)
+                        )
+                ),
+        Map.of(
+                        "department", "HR",
+                        "items", Arrays.asList(
+                                Map.of("name", "Jane", "department", "HR", "age", 25, "salary", 45000),
+                                Map.of("name", "Alice", "department", "HR", "age", 28, "salary", 48000)
+                        )
+                )
+        );
+
+        Map<String, Object> params = Map.of(
+                "aggregations", Arrays.asList(
+                        Map.of("field", "salary", "function", "sum", "alias", "total_salary"),
+                        Map.of("field", "age", "function", "avg", "alias", "avg_age"),
+                        Map.of("field", "name", "function", "count", "alias", "employee_count")
+                )
+        );
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> result = (List<Map<String, Object>>) aggregateTransformer.transform(groups, params);
+
+        assertEquals(2, result.size());
+
+        Map<String, Object> itResult = result.stream()
+                .filter(r -> "IT".equals(r.get("department")))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(110000.0, itResult.get("total_salary"));
+        assertEquals(32.5, itResult.get("avg_age"));
+        assertEquals(2, itResult.get("employee_count"));
+    }
+
+    @Test
+    void testTransformWithDifferentFunctions() {
+        List<Map<String, Object>> groups = List.of(
+                Map.of(
+                        "department", "IT",
+                        "items", Arrays.asList(
+                                Map.of("department", "IT", "salary", 50000, "bonus", 5000),
+                                Map.of("department", "IT", "salary", 60000, "bonus", 6000),
+                                Map.of("department", "IT", "salary", 55000, "bonus", 5500)
+                        )
+                )
+        );
+
+        Map<String, Object> params = Map.of(
+                "aggregations", Arrays.asList(
+                        Map.of("field", "salary", "function", "min", "alias", "min_salary"),
+                        Map.of("field", "salary", "function", "max", "alias", "max_salary"),
+                        Map.of("field", "bonus", "function", "sum", "alias", "total_bonus")
+                )
+        );
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> result = (List<Map<String, Object>>) aggregateTransformer.transform(groups, params);
+
+        Map<String, Object> itResult = result.getFirst();
+        assertEquals(50000, itResult.get("min_salary"));
+        assertEquals(60000, itResult.get("max_salary"));
+        assertEquals(16500.0, itResult.get("total_bonus"));
+    }
+}
+

--- a/src/test/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/GroupByTransformerTest.java
+++ b/src/test/java/org/phong/zenflow/plugin/subdomain/executors/builtin/data/data_transformer/impl/aggregation/GroupByTransformerTest.java
@@ -4,15 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.phong.zenflow.plugin.subdomain.executors.builtin.data.data_transformer.exception.DataTransformerExecutorException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GroupByTransformerTest {
 
@@ -29,89 +23,11 @@ class GroupByTransformerTest {
     }
 
     @Test
-    void testTransformGroupByFieldWithAggregations() {
+    void testTransformGroupByField() {
         List<Map<String, Object>> input = Arrays.asList(
-                Map.of("name", "John", "department", "IT", "age", 30, "salary", 50000),
-                Map.of("name", "Jane", "department", "HR", "age", 25, "salary", 45000),
-                Map.of("name", "Bob", "department", "IT", "age", 35, "salary", 60000),
-                Map.of("name", "Alice", "department", "HR", "age", 28, "salary", 48000)
-        );
-
-        Map<String, Object> params = Map.of(
-                "groupBy", "department",
-                "aggregations", Arrays.asList(
-                        Map.of("field", "salary", "function", "sum", "alias", "total_salary"),
-                        Map.of("field", "age", "function", "avg", "alias", "avg_age"),
-                        Map.of("field", "name", "function", "count", "alias", "employee_count")
-                )
-        );
-
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> result = (List<Map<String, Object>>) groupByTransformer.transform(input, params);
-
-        assertEquals(2, result.size());
-
-        // Find IT department result
-        Map<String, Object> itResult = result.stream()
-                .filter(r -> "IT".equals(r.get("department")))
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("IT", itResult.get("department"));
-        assertEquals(110000.0, itResult.get("total_salary")); // 50000 + 60000
-        assertEquals(32.5, itResult.get("avg_age")); // (30 + 35) / 2
-        assertEquals(2, itResult.get("employee_count"));
-
-        // Find HR department result
-        Map<String, Object> hrResult = result.stream()
-                .filter(r -> "HR".equals(r.get("department")))
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("HR", hrResult.get("department"));
-        assertEquals(93000.0, hrResult.get("total_salary")); // 45000 + 48000
-        assertEquals(26.5, hrResult.get("avg_age")); // (25 + 28) / 2
-        assertEquals(2, hrResult.get("employee_count"));
-    }
-
-    @Test
-    void testTransformGroupByMultipleFields() {
-        List<Map<String, Object>> input = Arrays.asList(
-                Map.of("department", "IT", "level", "Junior", "salary", 40000),
-                Map.of("department", "IT", "level", "Senior", "salary", 70000),
-                Map.of("department", "HR", "level", "Junior", "salary", 35000),
-                Map.of("department", "HR", "level", "Senior", "salary", 65000)
-        );
-
-        Map<String, Object> params = Map.of(
-                "groupBy", Arrays.asList("department", "level"),
-                "aggregations", List.of(
-                        Map.of("field", "salary", "function", "avg", "alias", "avg_salary")
-                )
-        );
-
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> result = (List<Map<String, Object>>) groupByTransformer.transform(input, params);
-
-        assertEquals(4, result.size());
-
-        // Verify one of the groups
-        Map<String, Object> itJuniorResult = result.stream()
-                .filter(r -> "IT".equals(r.get("department")) && "Junior".equals(r.get("level")))
-                .findFirst()
-                .orElseThrow();
-
-        assertEquals("IT", itJuniorResult.get("department"));
-        assertEquals("Junior", itJuniorResult.get("level"));
-        assertEquals(40000.0, itJuniorResult.get("avg_salary"));
-    }
-
-    @Test
-    void testTransformWithoutAggregations() {
-        List<Map<String, Object>> input = Arrays.asList(
-                Map.of("name", "John", "department", "IT"),
-                Map.of("name", "Jane", "department", "HR"),
-                Map.of("name", "Bob", "department", "IT")
+                Map.of("name", "John", "department", "IT", "age", 30),
+                Map.of("name", "Jane", "department", "HR", "age", 25),
+                Map.of("name", "Bob", "department", "IT", "age", 35)
         );
 
         Map<String, Object> params = Map.of("groupBy", "department");
@@ -121,9 +37,38 @@ class GroupByTransformerTest {
 
         assertEquals(2, result.size());
 
-        // Should still group but without aggregations
-        assertTrue(result.stream().anyMatch(r -> "IT".equals(r.get("department"))));
-        assertTrue(result.stream().anyMatch(r -> "HR".equals(r.get("department"))));
+        Map<String, Object> itGroup = result.stream()
+                .filter(r -> "IT".equals(r.get("department")))
+                .findFirst()
+                .orElseThrow();
+
+        assertTrue(itGroup.containsKey("items"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> itItems = (List<Map<String, Object>>) itGroup.get("items");
+        assertEquals(2, itItems.size());
+    }
+
+    @Test
+    void testTransformGroupByMultipleFields() {
+        List<Map<String, Object>> input = Arrays.asList(
+                Map.of("department", "IT", "level", "Junior"),
+                Map.of("department", "IT", "level", "Senior"),
+                Map.of("department", "HR", "level", "Junior")
+        );
+
+        Map<String, Object> params = Map.of("groupBy", Arrays.asList("department", "level"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> result = (List<Map<String, Object>>) groupByTransformer.transform(input, params);
+
+        assertEquals(3, result.size());
+
+        Map<String, Object> itJunior = result.stream()
+                .filter(r -> "IT".equals(r.get("department")) && "Junior".equals(r.get("level")))
+                .findFirst()
+                .orElseThrow();
+
+        assertTrue(itJunior.containsKey("items"));
     }
 
     @Test
@@ -139,19 +84,12 @@ class GroupByTransformerTest {
                 Map.of("name", "Alice") // Missing department field
         );
 
-        Map<String, Object> params = Map.of(
-                "groupBy", "department",
-                "aggregations", List.of(
-                        Map.of("field", "name", "function", "count", "alias", "count")
-                )
-        );
+        Map<String, Object> params = Map.of("groupBy", "department");
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> result = (List<Map<String, Object>>) groupByTransformer.transform(input, params);
 
         assertEquals(2, result.size());
-
-        // Should have IT group and null group
         assertTrue(result.stream().anyMatch(r -> "IT".equals(r.get("department"))));
         assertTrue(result.stream().anyMatch(r -> "null".equals(r.get("department"))));
     }
@@ -176,9 +114,7 @@ class GroupByTransformerTest {
 
     @Test
     void testTransformWithMissingGroupByParam() {
-        List<Map<String, Object>> input = List.of(
-                Map.of("name", "John", "department", "IT")
-        );
+        List<Map<String, Object>> input = List.of(Map.of("name", "John", "department", "IT"));
         Map<String, Object> params = new HashMap<>();
 
         assertThrows(DataTransformerExecutorException.class, () -> groupByTransformer.transform(input, params));
@@ -186,49 +122,17 @@ class GroupByTransformerTest {
 
     @Test
     void testTransformWithNullParams() {
-        List<Map<String, Object>> input = List.of(
-                Map.of("name", "John", "department", "IT")
-        );
+        List<Map<String, Object>> input = List.of(Map.of("name", "John", "department", "IT"));
 
         assertThrows(DataTransformerExecutorException.class, () -> groupByTransformer.transform(input, null));
     }
 
     @Test
     void testTransformWithInvalidGroupByParameter() {
-        List<Map<String, Object>> input = List.of(
-                Map.of("name", "John", "department", "IT")
-        );
-        Map<String, Object> params = Map.of("groupBy", 123); // Invalid type
+        List<Map<String, Object>> input = List.of(Map.of("name", "John", "department", "IT"));
+        Map<String, Object> params = Map.of("groupBy", 123);
 
         assertThrows(DataTransformerExecutorException.class, () -> groupByTransformer.transform(input, params));
     }
-
-    @Test
-    void testTransformWithDifferentAggregationFunctions() {
-        List<Map<String, Object>> input = Arrays.asList(
-            Map.of("department", "IT", "salary", 50000, "bonus", 5000),
-            Map.of("department", "IT", "salary", 60000, "bonus", 6000),
-            Map.of("department", "IT", "salary", 55000, "bonus", 5500)
-        );
-
-        Map<String, Object> params = Map.of(
-            "groupBy", "department",
-            "aggregations", Arrays.asList(
-                Map.of("field", "salary", "function", "min", "alias", "min_salary"),
-                Map.of("field", "salary", "function", "max", "alias", "max_salary"),
-                Map.of("field", "bonus", "function", "sum", "alias", "total_bonus")
-            )
-        );
-
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> result = (List<Map<String, Object>>) groupByTransformer.transform(input, params);
-
-        assertEquals(1, result.size());
-
-        Map<String, Object> itResult = result.getFirst();
-        assertEquals("IT", itResult.get("department"));
-        assertEquals(50000, itResult.get("min_salary")); // int, not double
-        assertEquals(60000, itResult.get("max_salary")); // int, not double
-        assertEquals(16500.0, itResult.get("total_bonus")); // double from sum function
-    }
 }
+


### PR DESCRIPTION
## Summary
- add AggregateTransformer to expose aggregation helpers
- simplify GroupByTransformer to only return grouped items
- register new transformer in registry and core node migration

## Testing
- `./gradlew test` *(fails: ZenflowApplicationTests > contextLoads())*

------
https://chatgpt.com/codex/tasks/task_b_689b4bc5b29c832d901ac3ddee400027