### PR TITLE
feat: add Google Docs plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:2.8.1'
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.38.0'
     implementation 'com.google.apis:google-api-services-drive:v3-rev20250829-2.0.0'
+    implementation 'com.google.apis:google-api-services-docs:v1-rev20250325-2.0.0'
     implementation 'com.google.http-client:google-http-client-jackson2:2.0.0'
 
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/docs/google-docs-plugin.md
+++ b/docs/google-docs-plugin.md
@@ -1,0 +1,40 @@
+# Google Docs Plugin
+
+The Google Docs plugin provides workflow nodes that interact with Google Docs documents. It allows workflows to create and manage documents within a user's Google account.
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| Document Management | Operations on the document as a whole, including creating, getting, and deleting documents. |
+| Content Manipulation | Operations on the content inside a document, such as inserting and deleting text, or adding images and tables. |
+| Formatting | Operations that apply styling to text, paragraphs, lists, and tables, such as changing font size or applying bold formatting. |
+| Structural Elements | Operations that manage structural parts of a document, including headers, footers, and named ranges. |
+| Collaboration | Operations related to collaborative features like comments and suggestions. |
+
+## Available Nodes
+
+| Category | Node | Description |
+|---------|------|-------------|
+| Document Management | `google-docs:documents.create` | Create a blank Google Docs document |
+| Document Management | `google-docs:documents.get` | Retrieve a Google Docs document |
+| Document Management | `google-docs:documents.delete` | Delete a Google Docs document |
+| Content Manipulation | `google-docs:documents.append_text` | Append text to a Google Docs document |
+| Content Manipulation | `google-docs:documents.delete_text` | Delete a range of text from a document |
+| Formatting | `google-docs:documents.format_text` | Apply text styling to a range in a document |
+| Structural Elements | `google-docs:documents.add_header` | Create a header and insert text |
+| Collaboration | `google-docs:documents.add_comment` | Add a comment to a document |
+
+## Credentials
+
+All nodes require an OAuth2 credential profile containing the following keys:
+
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
+
+Define profiles as secret groups and reference them through the `profile` property in node inputs.
+
+## Notes
+
+This plugin relies on the [Google Docs API](https://developers.google.com/docs/api) and uses the Docs v1 Java client.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/GoogleDocsServiceManager.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/GoogleDocsServiceManager.java
@@ -1,0 +1,63 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.DocsScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.UserCredentials;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.resource.BaseNodeResourceManager;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.TriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+/**
+ * Resource manager for Google Docs {@link Docs} clients.
+ * Uses the generic {@link BaseNodeResourceManager} infrastructure for
+ * sharing Docs instances across nodes.
+ */
+@Slf4j
+@Component
+public class GoogleDocsServiceManager extends BaseNodeResourceManager<Docs, TriggerResourceConfig> {
+
+    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+
+    @Override
+    protected Docs createResource(String resourceKey, TriggerResourceConfig config) {
+        try {
+            String clientId = config.getConfigValue("clientId", String.class);
+            String clientSecret = config.getConfigValue("clientSecret", String.class);
+            String refreshToken = config.getConfigValue("refreshToken", String.class);
+
+            HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+            GoogleCredentials credentials = UserCredentials.newBuilder()
+                    .setClientId(clientId)
+                    .setClientSecret(clientSecret)
+                    .setRefreshToken(refreshToken)
+                    .build();
+
+            return new Docs.Builder(
+                    httpTransport,
+                    JSON_FACTORY,
+                    new HttpCredentialsAdapter(credentials.createScoped(List.of(DocsScopes.DOCUMENTS))))
+                    .setApplicationName("Zenflow")
+                    .build();
+        } catch (GeneralSecurityException | IOException e) {
+            log.error("Failed to create Docs client: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to create Docs client", e);
+        }
+    }
+
+    @Override
+    protected void cleanupResource(Docs docs) {
+        // Docs clients do not require explicit cleanup
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/GoogleDocsAddCommentExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/GoogleDocsAddCommentExecutor.java
@@ -1,0 +1,78 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.add_comment;
+
+import com.google.api.services.drive.Drive;
+import com.google.api.services.drive.model.Comment;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.drive.share.GoogleDriveServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.add_comment",
+        name = "Google Docs - Add Comment",
+        version = "1.0.0",
+        description = "Adds a comment to a Google Docs document using the Drive API.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "comment"}
+)
+public class GoogleDocsAddCommentExecutor implements PluginNodeExecutor {
+
+    private final GoogleDriveServiceManager driveServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+            String content = (String) input.get("content");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Drive> handle =
+                         driveServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Drive drive = handle.getResource();
+
+                Comment comment = new Comment();
+                comment.setContent(content);
+                Comment created = drive.comments().create(documentId, comment).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", documentId);
+                output.put("commentId", created.getId());
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs add comment failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/doc.md
@@ -1,0 +1,55 @@
+# Google Docs - Add Comment Node
+
+## Overview
+Adds a comment to an existing Google Docs document using the Drive API.
+
+## Node Information
+- **Key**: `google-docs:documents.add_comment`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:chat-circle-text`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Creates a new comment on the specified document using OAuth2 credentials. Drive client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to comment on.
+- `content` (string, required): Comment text.
+
+### Output
+- `documentId` (string): ID of the document.
+- `commentId` (string): ID of the created comment.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D",
+    "content": "Please review this section"
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Add Comment Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to comment on"
+        },
+        "content": {
+          "type": "string",
+          "description": "Comment text"
+        }
+      },
+      "required": ["profile", "documentId", "content"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/GoogleDocsAddHeaderExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/GoogleDocsAddHeaderExecutor.java
@@ -1,0 +1,94 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.add_header;
+
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.model.BatchUpdateDocumentRequest;
+import com.google.api.services.docs.v1.model.BatchUpdateDocumentResponse;
+import com.google.api.services.docs.v1.model.CreateHeaderRequest;
+import com.google.api.services.docs.v1.model.InsertTextRequest;
+import com.google.api.services.docs.v1.model.Location;
+import com.google.api.services.docs.v1.model.Request;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.GoogleDocsServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.add_header",
+        name = "Google Docs - Add Header",
+        version = "1.0.0",
+        description = "Creates a header in a Google Docs document and inserts provided text.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "header"}
+)
+public class GoogleDocsAddHeaderExecutor implements PluginNodeExecutor {
+
+    private final GoogleDocsServiceManager docsServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+            String text = (String) input.getOrDefault("text", "");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Docs> handle =
+                         docsServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Docs docs = handle.getResource();
+
+                Request createHeader = new Request().setCreateHeader(new CreateHeaderRequest());
+                BatchUpdateDocumentResponse response = docs.documents().batchUpdate(documentId,
+                        new BatchUpdateDocumentRequest().setRequests(List.of(createHeader))).execute();
+                String headerId = response.getReplies().get(0).getCreateHeader().getHeaderId();
+
+                if (text != null && !text.isEmpty()) {
+                    InsertTextRequest insert = new InsertTextRequest()
+                            .setText(text)
+                            .setLocation(new Location().setSegmentId(headerId).setIndex(0));
+                    docs.documents().batchUpdate(documentId,
+                            new BatchUpdateDocumentRequest().setRequests(List.of(new Request().setInsertText(insert))))
+                            .execute();
+                }
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", documentId);
+                output.put("headerId", headerId);
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs add header failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/doc.md
@@ -1,0 +1,55 @@
+# Google Docs - Add Header Node
+
+## Overview
+Creates a header in an existing Google Docs document and optionally inserts text into it.
+
+## Node Information
+- **Key**: `google-docs:documents.add_header`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:header`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Uses the Google Docs API to create a new header in the specified document. If text is provided, it is inserted at the beginning of the header. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to modify.
+- `text` (string, optional): Text to insert into the new header.
+
+### Output
+- `documentId` (string): ID of the modified document.
+- `headerId` (string): ID of the created header.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D",
+    "text": "Confidential"
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Add Header Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to modify"
+        },
+        "text": {
+          "type": "string",
+          "description": "Text to insert into the new header"
+        }
+      },
+      "required": ["profile", "documentId"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/GoogleDocsAppendTextExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/GoogleDocsAppendTextExecutor.java
@@ -1,0 +1,86 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.append_text;
+
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.model.BatchUpdateDocumentRequest;
+import com.google.api.services.docs.v1.model.EndOfSegmentLocation;
+import com.google.api.services.docs.v1.model.InsertTextRequest;
+import com.google.api.services.docs.v1.model.Request;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.GoogleDocsServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.append_text",
+        name = "Google Docs - Append Text",
+        version = "1.0.0",
+        description = "Appends text to the end of a Google Docs document using OAuth2 credentials.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "append", "text", "document"}
+)
+public class GoogleDocsAppendTextExecutor implements PluginNodeExecutor {
+
+    private final GoogleDocsServiceManager docsServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+            String text = (String) input.get("text");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Docs> handle =
+                         docsServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Docs docs = handle.getResource();
+
+                InsertTextRequest insert = new InsertTextRequest()
+                        .setText(text)
+                        .setEndOfSegmentLocation(new EndOfSegmentLocation());
+                Request request = new Request().setInsertText(insert);
+                BatchUpdateDocumentRequest body = new BatchUpdateDocumentRequest()
+                        .setRequests(List.of(request));
+
+                docs.documents().batchUpdate(documentId, body).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", documentId);
+                output.put("text", text);
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs append text failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/doc.md
@@ -1,0 +1,55 @@
+# Google Docs - Append Text Node
+
+## Overview
+Appends text to the end of an existing Google Docs document using the Google Docs API v1.
+
+## Node Information
+- **Key**: `google-docs:documents.append_text`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:file-text`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Adds the provided text to the end of the specified document using OAuth2 credentials. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to modify.
+- `text` (string, required): Text to append to the document.
+
+### Output
+- `documentId` (string): ID of the modified document.
+- `text` (string): The appended text.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D",
+    "text": "Hello world!"
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Append Text Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to modify"
+        },
+        "text": {
+          "type": "string",
+          "description": "Text to append to the document"
+        }
+      },
+      "required": ["profile", "documentId", "text"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/GoogleDocsCreateExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/GoogleDocsCreateExecutor.java
@@ -1,0 +1,78 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.create;
+
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.model.Document;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.GoogleDocsServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.create",
+        name = "Google Docs - Create Document",
+        version = "1.0.0",
+        description = "Creates a new Google Docs document using OAuth2 credentials.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "create", "document"}
+)
+public class GoogleDocsCreateExecutor implements PluginNodeExecutor {
+
+    private final GoogleDocsServiceManager docsServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String title = (String) input.getOrDefault("title", "Untitled Document");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Docs> handle =
+                         docsServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Docs docs = handle.getResource();
+
+                Document request = new Document();
+                request.setTitle(title);
+
+                Document created = docs.documents().create(request).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", created.getDocumentId());
+                output.put("title", created.getTitle());
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs create failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/doc.md
@@ -1,0 +1,53 @@
+# Google Docs - Create Document Node
+
+## Overview
+Creates a blank Google Docs document using the Google Docs API v1.
+
+## Node Information
+- **Key**: `google-docs:documents.create`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:file-text`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Uses OAuth2 credentials to access Google Docs and create a new document. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `title` (string): Title for the new document. Defaults to `Untitled Document`.
+
+### Output
+- `documentId` (string): ID of the created document.
+- `title` (string): Title of the created document.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "title": "My Document"
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Create Document Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the document to create",
+          "default": "Untitled Document"
+        }
+      },
+      "required": ["profile"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/GoogleDocsDeleteExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/GoogleDocsDeleteExecutor.java
@@ -1,0 +1,73 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.delete;
+
+import com.google.api.services.drive.Drive;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.drive.share.GoogleDriveServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.delete",
+        name = "Google Docs - Delete Document",
+        version = "1.0.0",
+        description = "Permanently deletes a Google Docs document using OAuth2 credentials.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "delete", "document"}
+)
+public class GoogleDocsDeleteExecutor implements PluginNodeExecutor {
+
+    private final GoogleDriveServiceManager driveServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Drive> handle =
+                         driveServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Drive drive = handle.getResource();
+
+                drive.files().delete(documentId).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", documentId);
+                output.put("deleted", true);
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs delete failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/doc.md
@@ -1,0 +1,53 @@
+# Google Docs - Delete Document Node
+
+## Overview
+Permanently deletes a Google Docs document using the Google Drive API.
+
+## Node Information
+- **Key**: `google-docs:documents.delete`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:file-text`
+- **Tags**: `google`, `docs`, `document`, `integration`, `delete`
+
+## Description
+Removes the specified document by ID using OAuth2 credentials. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to delete.
+
+### Output
+- `documentId` (string): ID of the deleted document.
+- `deleted` (boolean): Whether the document was deleted.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D"
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Delete Document Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to delete"
+        }
+      },
+      "required": ["profile", "documentId"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/GoogleDocsDeleteTextExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/GoogleDocsDeleteTextExecutor.java
@@ -1,0 +1,85 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.delete_text;
+
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.model.BatchUpdateDocumentRequest;
+import com.google.api.services.docs.v1.model.DeleteContentRangeRequest;
+import com.google.api.services.docs.v1.model.Range;
+import com.google.api.services.docs.v1.model.Request;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.GoogleDocsServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.delete_text",
+        name = "Google Docs - Delete Text",
+        version = "1.0.0",
+        description = "Deletes a range of text within a Google Docs document using OAuth2 credentials.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "delete", "text"}
+)
+public class GoogleDocsDeleteTextExecutor implements PluginNodeExecutor {
+
+    private final GoogleDocsServiceManager docsServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+            Number start = (Number) input.get("startIndex");
+            Number end = (Number) input.get("endIndex");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Docs> handle =
+                         docsServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Docs docs = handle.getResource();
+
+                Range range = new Range().setStartIndex(start.intValue()).setEndIndex(end.intValue());
+                Request request = new Request().setDeleteContentRange(
+                        new DeleteContentRangeRequest().setRange(range));
+                BatchUpdateDocumentRequest body = new BatchUpdateDocumentRequest().setRequests(List.of(request));
+                docs.documents().batchUpdate(documentId, body).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", documentId);
+                output.put("deleted", true);
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs delete text failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/doc.md
@@ -1,0 +1,57 @@
+# Google Docs - Delete Text Node
+
+## Overview
+Deletes a range of text from an existing Google Docs document using the Google Docs API v1.
+
+## Node Information
+- **Key**: `google-docs:documents.delete_text`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:file-text`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Removes the specified text range from a document using OAuth2 credentials. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to modify.
+- `startIndex` (integer, required): Start index of the range to delete.
+- `endIndex` (integer, required): End index of the range to delete.
+
+### Output
+- `documentId` (string): ID of the modified document.
+- `deleted` (boolean): Indicates the delete operation succeeded.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D",
+    "startIndex": 1,
+    "endIndex": 5
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Delete Text Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to modify"
+        },
+        "startIndex": {
+          "type": "integer",
+          "description": "Start index of the range to delete"
+        },
+        "endIndex": {
+          "type": "integer",
+          "description": "End index of the range to delete"
+        }
+      },
+      "required": ["profile", "documentId", "startIndex", "endIndex"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/GoogleDocsFormatTextExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/GoogleDocsFormatTextExecutor.java
@@ -1,0 +1,98 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.format_text;
+
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.model.BatchUpdateDocumentRequest;
+import com.google.api.services.docs.v1.model.Range;
+import com.google.api.services.docs.v1.model.Request;
+import com.google.api.services.docs.v1.model.TextStyle;
+import com.google.api.services.docs.v1.model.UpdateTextStyleRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.GoogleDocsServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.format_text",
+        name = "Google Docs - Format Text",
+        version = "1.0.0",
+        description = "Applies text styling, such as bold or font size, to a range within a Google Docs document.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "format", "text"}
+)
+public class GoogleDocsFormatTextExecutor implements PluginNodeExecutor {
+
+    private final GoogleDocsServiceManager docsServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+            Number start = (Number) input.get("startIndex");
+            Number end = (Number) input.get("endIndex");
+            Boolean bold = (Boolean) input.getOrDefault("bold", Boolean.FALSE);
+            Number fontSize = (Number) input.get("fontSize");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Docs> handle =
+                         docsServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Docs docs = handle.getResource();
+
+                TextStyle style = new TextStyle().setBold(bold);
+                if (fontSize != null) {
+                    style.setFontSize(new com.google.api.services.docs.v1.model.Dimension()
+                            .setMagnitude(fontSize.doubleValue())
+                            .setUnit("PT"));
+                }
+
+                UpdateTextStyleRequest styleRequest = new UpdateTextStyleRequest()
+                        .setRange(new Range().setStartIndex(start.intValue()).setEndIndex(end.intValue()))
+                        .setTextStyle(style)
+                        .setFields(fontSize != null ? "bold,fontSize" : "bold");
+
+                Request request = new Request().setUpdateTextStyle(styleRequest);
+                BatchUpdateDocumentRequest body = new BatchUpdateDocumentRequest().setRequests(List.of(request));
+                docs.documents().batchUpdate(documentId, body).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", documentId);
+                output.put("formatted", true);
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs format text failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/doc.md
@@ -1,0 +1,61 @@
+# Google Docs - Format Text Node
+
+## Overview
+Applies text formatting to an existing Google Docs document using the Google Docs API v1.
+
+## Node Information
+- **Key**: `google-docs:documents.format_text`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:text-b-bold`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Updates the style of text within a specified range, such as applying bold formatting or changing the font size. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to modify.
+- `startIndex` (integer, required): Start index of the range to format.
+- `endIndex` (integer, required): End index of the range to format.
+- `bold` (boolean, optional): Whether to apply bold formatting. Defaults to `false`.
+- `fontSize` (number, optional): Font size in points to apply to the range.
+
+### Output
+- `documentId` (string): ID of the modified document.
+- `formatted` (boolean): Indicates the format operation succeeded.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D",
+    "startIndex": 1,
+    "endIndex": 5,
+    "bold": true,
+    "fontSize": 14
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Format Text Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to modify"
+        },
+        "startIndex": {
+          "type": "integer",
+          "description": "Start index of the range to format"
+        },
+        "endIndex": {
+          "type": "integer",
+          "description": "End index of the range to format"
+        },
+        "bold": {
+          "type": "boolean",
+          "description": "Whether to apply bold formatting"
+        },
+        "fontSize": {
+          "type": "number",
+          "description": "Font size in points to apply"
+        }
+      },
+      "required": ["profile", "documentId", "startIndex", "endIndex"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/GoogleDocsGetExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/GoogleDocsGetExecutor.java
@@ -1,0 +1,75 @@
+package org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.documents.get;
+
+import com.google.api.services.docs.v1.Docs;
+import com.google.api.services.docs.v1.model.Document;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phong.zenflow.plugin.subdomain.execution.dto.ExecutionResult;
+import org.phong.zenflow.plugin.subdomain.execution.interfaces.PluginNodeExecutor;
+import org.phong.zenflow.plugin.subdomain.node.registry.PluginNode;
+import org.phong.zenflow.plugin.subdomain.nodes.builtin.integration.google.docs.GoogleDocsServiceManager;
+import org.phong.zenflow.plugin.subdomain.resource.ScopedNodeResource;
+import org.phong.zenflow.workflow.subdomain.context.ExecutionContext;
+import org.phong.zenflow.workflow.subdomain.logging.core.NodeLogPublisher;
+import org.phong.zenflow.workflow.subdomain.node_definition.definitions.dto.WorkflowConfig;
+import org.phong.zenflow.workflow.subdomain.trigger.resource.DefaultTriggerResourceConfig;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PluginNode(
+        key = "google-docs:documents.get",
+        name = "Google Docs - Get Document",
+        version = "1.0.0",
+        description = "Retrieves a Google Docs document using OAuth2 credentials.",
+        icon = "simple-icons:googledocs",
+        type = "integration.documents",
+        tags = {"google", "docs", "get", "document"}
+)
+public class GoogleDocsGetExecutor implements PluginNodeExecutor {
+
+    private final GoogleDocsServiceManager docsServiceManager;
+
+    @Override
+    public ExecutionResult execute(WorkflowConfig config, ExecutionContext context) {
+        NodeLogPublisher logCollector = context.getLogPublisher();
+        try {
+            Map<String, Object> input = config.input();
+            String profile = (String) input.get("profile");
+            String documentId = (String) input.get("documentId");
+
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
+            Map<String, String> credentials = secretMap.get(profile);
+            String clientId = credentials.get("CLIENT_ID");
+            String clientSecret = credentials.get("CLIENT_SECRET");
+            String refreshToken = credentials.get("REFRESH_TOKEN");
+
+            Map<String, Object> cfg = new HashMap<>();
+            cfg.put("clientId", clientId);
+            cfg.put("clientSecret", clientSecret);
+            cfg.put("refreshToken", refreshToken);
+            DefaultTriggerResourceConfig resourceConfig = new DefaultTriggerResourceConfig(cfg, "refreshToken");
+
+            try (ScopedNodeResource<Docs> handle =
+                         docsServiceManager.acquire(refreshToken, context.getWorkflowRunId(), resourceConfig)) {
+                Docs docs = handle.getResource();
+
+                Document document = docs.documents().get(documentId).execute();
+
+                Map<String, Object> output = new HashMap<>();
+                output.put("documentId", document.getDocumentId());
+                output.put("title", document.getTitle());
+                output.put("document", document);
+                return ExecutionResult.success(output);
+            }
+        } catch (Exception e) {
+            logCollector.withException(e).error("Google Docs get failed: {}", e.getMessage());
+            return ExecutionResult.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/doc.md
@@ -1,0 +1,54 @@
+# Google Docs - Get Document Node
+
+## Overview
+Retrieves a Google Docs document including metadata and content using the Google Docs API v1.
+
+## Node Information
+- **Key**: `google-docs:documents.get`
+- **Version**: `1.0.0`
+- **Type**: `action`
+- **Icon**: `ph:file-text`
+- **Tags**: `google`, `docs`, `document`, `integration`
+
+## Description
+Fetches the specified document by ID using OAuth2 credentials. Docs client instances are cached through the global node resource manager to maximize efficiency in high concurrency environments.
+
+## Input/Output
+### Input
+- `profile` (string, required): Secret profile group containing OAuth credentials.
+- `documentId` (string, required): ID of the document to retrieve.
+
+### Output
+- `documentId` (string): ID of the retrieved document.
+- `title` (string): Title of the document.
+- `document` (object): Full `Document` resource returned by the Google Docs API.
+
+## Usage Example
+```json
+{
+  "input": {
+    "profile": "my-google-docs-profile",
+    "documentId": "1A2B3C4D"
+  }
+}
+```
+
+## Credentials
+Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+
+```json
+{
+  "profiles": [
+    {
+      "name": "my-google-docs-profile",
+      "keys": {
+        "CLIENT_ID": "<client id>",
+        "CLIENT_SECRET": "<client secret>",
+        "REFRESH_TOKEN": "<refresh token>"
+      }
+    }
+  ]
+}
+```
+
+The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Google Docs Get Document Schema",
+  "properties": {
+    "input": {
+      "type": "object",
+      "title": "Input Schema",
+      "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Secret profile group name containing OAuth credentials"
+        },
+        "documentId": {
+          "type": "string",
+          "description": "ID of the document to retrieve"
+        }
+      },
+      "required": ["profile", "documentId"],
+      "additionalProperties": false
+    },
+    "output": {
+      "type": "object",
+      "title": "Output Schema"
+    },
+    "profiles": {
+      "type": "array",
+      "title": "Credential Profiles",
+      "description": "Secret groups with required Google OAuth keys",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "title": "Profile Definition",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Profile name referencing a stored secret group"
+          },
+          "keys": {
+            "type": "object",
+            "description": "Required secret keys for this profile",
+            "properties": {
+              "CLIENT_ID": { "type": "string" },
+              "CLIENT_SECRET": { "type": "string" },
+              "REFRESH_TOKEN": { "type": "string" }
+            },
+            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "keys"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["input", "output", "profiles"],
+  "additionalProperties": false
+}

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/registry/definitions/GoogleDocsPlugin.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/registry/definitions/GoogleDocsPlugin.java
@@ -1,0 +1,22 @@
+package org.phong.zenflow.plugin.subdomain.registry.definitions;
+
+import org.phong.zenflow.plugin.subdomain.registry.Plugin;
+import org.springframework.stereotype.Component;
+
+/**
+ * Google Docs plugin definition providing Google Docs nodes.
+ */
+@Component
+@Plugin(
+    key = "google-docs",
+    name = "Google Docs Plugin",
+    version = "1.0.0",
+    description = "Plugin providing nodes that interact with Google Docs.",
+    tags = {"google", "docs", "integration"},
+    icon = "simple-icons:googledocs",
+    organization = "google"
+)
+public class GoogleDocsPlugin {
+    // Marker class for Google Docs plugin definition
+}
+

--- a/src/test/java/org/phong/zenflow/plugin/subdomain/registry/PluginTest.java
+++ b/src/test/java/org/phong/zenflow/plugin/subdomain/registry/PluginTest.java
@@ -202,6 +202,8 @@ public class PluginTest {
         CorePlugin corePlugin = new CorePlugin();
         IntegrationPlugin integrationPlugin = new IntegrationPlugin();
         TestPlugin testPlugin = new TestPlugin();
+        GoogleDrivePlugin googleDrivePlugin = new GoogleDrivePlugin();
+        GoogleDocsPlugin googleDocsPlugin = new GoogleDocsPlugin();
 
         // Verify that the classes have the @Plugin annotation
         assertTrue(CorePlugin.class.isAnnotationPresent(
@@ -215,6 +217,14 @@ public class PluginTest {
         assertTrue(TestPlugin.class.isAnnotationPresent(
                 org.phong.zenflow.plugin.subdomain.registry.Plugin.class),
                 "TestPlugin should have @Plugin annotation");
+
+        assertTrue(GoogleDrivePlugin.class.isAnnotationPresent(
+                org.phong.zenflow.plugin.subdomain.registry.Plugin.class),
+                "GoogleDrivePlugin should have @Plugin annotation");
+
+        assertTrue(GoogleDocsPlugin.class.isAnnotationPresent(
+                org.phong.zenflow.plugin.subdomain.registry.Plugin.class),
+                "GoogleDocsPlugin should have @Plugin annotation");
 
         // Verify annotation values for CorePlugin
         org.phong.zenflow.plugin.subdomain.registry.Plugin coreAnnotation =
@@ -249,6 +259,28 @@ public class PluginTest {
         assertFalse(testAnnotation.description().isEmpty(), "Test plugin should have a description");
         assertTrue(testAnnotation.tags().length > 0, "Test plugin should have tags");
         assertEquals("ph:test-tube", testAnnotation.icon(), "Test plugin should have correct icon");
+
+        // Verify annotation values for GoogleDrivePlugin
+        org.phong.zenflow.plugin.subdomain.registry.Plugin driveAnnotation =
+                GoogleDrivePlugin.class.getAnnotation(org.phong.zenflow.plugin.subdomain.registry.Plugin.class);
+
+        assertEquals("google-drive", driveAnnotation.key(), "Drive plugin key should be 'google-drive'");
+        assertEquals("Google Drive Plugin", driveAnnotation.name(), "Drive plugin name should be 'Google Drive Plugin'");
+        assertEquals("1.0.0", driveAnnotation.version(), "Drive plugin version should be '1.0.0'");
+        assertFalse(driveAnnotation.description().isEmpty(), "Drive plugin should have a description");
+        assertTrue(driveAnnotation.tags().length > 0, "Drive plugin should have tags");
+        assertEquals("simple-icons:googledrive", driveAnnotation.icon(), "Drive plugin should have correct icon");
+
+        // Verify annotation values for GoogleDocsPlugin
+        org.phong.zenflow.plugin.subdomain.registry.Plugin docsAnnotation =
+                GoogleDocsPlugin.class.getAnnotation(org.phong.zenflow.plugin.subdomain.registry.Plugin.class);
+
+        assertEquals("google-docs", docsAnnotation.key(), "Docs plugin key should be 'google-docs'");
+        assertEquals("Google Docs Plugin", docsAnnotation.name(), "Docs plugin name should be 'Google Docs Plugin'");
+        assertEquals("1.0.0", docsAnnotation.version(), "Docs plugin version should be '1.0.0'");
+        assertFalse(docsAnnotation.description().isEmpty(), "Docs plugin should have a description");
+        assertTrue(docsAnnotation.tags().length > 0, "Docs plugin should have tags");
+        assertEquals("simple-icons:googledocs", docsAnnotation.icon(), "Docs plugin should have correct icon");
     }
 
     @Test

--- a/src/test/java/org/phong/zenflow/plugin/subdomain/registry/PluginTest.java
+++ b/src/test/java/org/phong/zenflow/plugin/subdomain/registry/PluginTest.java
@@ -8,6 +8,7 @@ import org.phong.zenflow.plugin.subdomain.registry.definitions.CorePlugin;
 import org.phong.zenflow.plugin.subdomain.registry.definitions.IntegrationPlugin;
 import org.phong.zenflow.plugin.subdomain.registry.definitions.TestPlugin;
 import org.phong.zenflow.plugin.subdomain.registry.definitions.GoogleDrivePlugin;
+import org.phong.zenflow.plugin.subdomain.registry.definitions.GoogleDocsPlugin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.*;
         IntegrationPlugin.class,
         TestPlugin.class,
         GoogleDrivePlugin.class,
+        GoogleDocsPlugin.class,
         PluginSynchronizer.class,
         ObjectMapper.class
 })
@@ -154,14 +156,15 @@ public class PluginTest {
         assertDoesNotThrow(() -> pluginSynchronizer.run(null),
                 "Plugin synchronization should not throw any exceptions");
 
-        // Verify that all four plugins were saved
-        verify(pluginRepository, times(4)).save(any(Plugin.class));
+        // Verify that all five plugins were saved
+        verify(pluginRepository, times(5)).save(any(Plugin.class));
 
         // Verify each plugin key was searched for
         verify(pluginRepository).findByKey("core");
         verify(pluginRepository).findByKey("integration");
         verify(pluginRepository).findByKey("test");
         verify(pluginRepository).findByKey("google-drive");
+        verify(pluginRepository).findByKey("google-docs");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Document all Google Docs nodes by category
- Implement text deletion, formatting, header creation, and comment nodes
- Update plugin guide with expanded node list

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_68bbce1353a0832d8454338c731cba34