### PR TITLE
refactor: reference plugin profile for google nodes

### DIFF
--- a/docs/google-docs-plugin.md
+++ b/docs/google-docs-plugin.md
@@ -27,13 +27,13 @@ The Google Docs plugin provides workflow nodes that interact with Google Docs do
 
 ## Credentials
 
-All nodes require an OAuth2 credential profile containing the following keys:
+All nodes use a plugin-level OAuth profile containing the following keys:
 
 - `CLIENT_ID`
 - `CLIENT_SECRET`
 - `REFRESH_TOKEN`
 
-Define profiles as secret groups and reference them through the `profile` property in node inputs.
+Configure this profile once for the plugin and reference it via the `profile` property in node inputs.
 
 ## Notes
 

--- a/docs/google-drive-plugin.md
+++ b/docs/google-drive-plugin.md
@@ -19,13 +19,13 @@ The Google Drive plugin provides a collection of workflow nodes that interact wi
 
 ## Credentials
 
-All nodes require an OAuth2 credential profile containing the following keys:
+All nodes use a plugin-level OAuth profile containing the following keys:
 
 - `CLIENT_ID`
 - `CLIENT_SECRET`
 - `REFRESH_TOKEN`
 
-Define profiles as secret groups and reference them through the `profile` property in node inputs.
+Configure this profile once for the plugin and reference it via the `profile` property in node inputs.
 
 ## Notes
 

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/GoogleDocsServiceManager.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/GoogleDocsServiceManager.java
@@ -21,7 +21,9 @@ import java.util.List;
 /**
  * Resource manager for Google Docs {@link Docs} clients.
  * Uses the generic {@link BaseNodeResourceManager} infrastructure for
- * sharing Docs instances across nodes.
+ * sharing Docs instances across nodes. Credentials are sourced from
+ * the plugin-level OAuth profile referenced by each node's {@code profile}
+ * input.
  */
 @Slf4j
 @Component

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/GoogleDocsAddCommentExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/GoogleDocsAddCommentExecutor.java
@@ -44,8 +44,8 @@ public class GoogleDocsAddCommentExecutor implements PluginNodeExecutor {
             String content = (String) input.get("content");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/doc.md
@@ -35,21 +35,10 @@ Creates a new comment on the specified document using OAuth2 credentials. Drive 
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_comment/schema.json
@@ -20,43 +20,24 @@
           "description": "Comment text"
         }
       },
-      "required": ["profile", "documentId", "content"],
+      "required": [
+        "profile",
+        "documentId",
+        "content"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/GoogleDocsAddHeaderExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/GoogleDocsAddHeaderExecutor.java
@@ -50,8 +50,8 @@ public class GoogleDocsAddHeaderExecutor implements PluginNodeExecutor {
             String text = (String) input.getOrDefault("text", "");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/doc.md
@@ -35,21 +35,10 @@ Uses the Google Docs API to create a new header in the specified document. If te
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/add_header/schema.json
@@ -20,43 +20,23 @@
           "description": "Text to insert into the new header"
         }
       },
-      "required": ["profile", "documentId"],
+      "required": [
+        "profile",
+        "documentId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/GoogleDocsAppendTextExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/GoogleDocsAppendTextExecutor.java
@@ -48,8 +48,8 @@ public class GoogleDocsAppendTextExecutor implements PluginNodeExecutor {
             String text = (String) input.get("text");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/doc.md
@@ -35,21 +35,10 @@ Adds the provided text to the end of the specified document using OAuth2 credent
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/append_text/schema.json
@@ -20,43 +20,24 @@
           "description": "Text to append to the document"
         }
       },
-      "required": ["profile", "documentId", "text"],
+      "required": [
+        "profile",
+        "documentId",
+        "text"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/GoogleDocsCreateExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/GoogleDocsCreateExecutor.java
@@ -43,8 +43,8 @@ public class GoogleDocsCreateExecutor implements PluginNodeExecutor {
             String title = (String) input.getOrDefault("title", "Untitled Document");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/doc.md
@@ -33,21 +33,10 @@ Uses OAuth2 credentials to access Google Docs and create a new document. Docs cl
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/create/schema.json
@@ -17,43 +17,22 @@
           "default": "Untitled Document"
         }
       },
-      "required": ["profile"],
+      "required": [
+        "profile"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/GoogleDocsDeleteExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/GoogleDocsDeleteExecutor.java
@@ -42,8 +42,8 @@ public class GoogleDocsDeleteExecutor implements PluginNodeExecutor {
             String documentId = (String) input.get("documentId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/doc.md
@@ -33,21 +33,10 @@ Removes the specified document by ID using OAuth2 credentials. Docs client insta
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete/schema.json
@@ -16,43 +16,23 @@
           "description": "ID of the document to delete"
         }
       },
-      "required": ["profile", "documentId"],
+      "required": [
+        "profile",
+        "documentId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/GoogleDocsDeleteTextExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/GoogleDocsDeleteTextExecutor.java
@@ -49,8 +49,8 @@ public class GoogleDocsDeleteTextExecutor implements PluginNodeExecutor {
             Number end = (Number) input.get("endIndex");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/doc.md
@@ -37,21 +37,10 @@ Removes the specified text range from a document using OAuth2 credentials. Docs 
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/delete_text/schema.json
@@ -24,43 +24,25 @@
           "description": "End index of the range to delete"
         }
       },
-      "required": ["profile", "documentId", "startIndex", "endIndex"],
+      "required": [
+        "profile",
+        "documentId",
+        "startIndex",
+        "endIndex"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/GoogleDocsFormatTextExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/GoogleDocsFormatTextExecutor.java
@@ -52,8 +52,8 @@ public class GoogleDocsFormatTextExecutor implements PluginNodeExecutor {
             Number fontSize = (Number) input.get("fontSize");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/doc.md
@@ -41,21 +41,10 @@ Updates the style of text within a specified range, such as applying bold format
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/format_text/schema.json
@@ -32,43 +32,25 @@
           "description": "Font size in points to apply"
         }
       },
-      "required": ["profile", "documentId", "startIndex", "endIndex"],
+      "required": [
+        "profile",
+        "documentId",
+        "startIndex",
+        "endIndex"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/GoogleDocsGetExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/GoogleDocsGetExecutor.java
@@ -43,8 +43,8 @@ public class GoogleDocsGetExecutor implements PluginNodeExecutor {
             String documentId = (String) input.get("documentId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/doc.md
@@ -34,21 +34,10 @@ Fetches the specified document by ID using OAuth2 credentials. Docs client insta
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-docs-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-docs-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-docs-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/docs/documents/get/schema.json
@@ -16,43 +16,23 @@
           "description": "ID of the document to retrieve"
         }
       },
-      "required": ["profile", "documentId"],
+      "required": [
+        "profile",
+        "documentId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/copy/GoogleDriveCopyExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/copy/GoogleDriveCopyExecutor.java
@@ -46,8 +46,8 @@ public class GoogleDriveCopyExecutor implements PluginNodeExecutor {
             String name = (String) input.get("name");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/copy/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/copy/doc.md
@@ -26,4 +26,4 @@ Creates a copy of an existing file in Google Drive. You can optionally specify a
 - `webViewLink` (string): Link to view the file in Google Drive.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/copy/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/copy/schema.json
@@ -24,40 +24,23 @@
           "description": "New name for the copied file"
         }
       },
-      "required": ["profile", "fileId"],
+      "required": [
+        "profile",
+        "fileId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/delete/GoogleDriveDeleteExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/delete/GoogleDriveDeleteExecutor.java
@@ -42,8 +42,8 @@ public class GoogleDriveDeleteExecutor implements PluginNodeExecutor {
             String fileId = (String) input.get("fileId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/delete/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/delete/doc.md
@@ -19,4 +19,4 @@ Permanently deletes a file from Google Drive.
 - `deleted` (boolean): Indicates whether the file was deleted.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/delete/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/delete/schema.json
@@ -16,40 +16,23 @@
           "description": "ID of the file to delete"
         }
       },
-      "required": ["profile", "fileId"],
+      "required": [
+        "profile",
+        "fileId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/download/GoogleDriveDownloadExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/download/GoogleDriveDownloadExecutor.java
@@ -45,8 +45,8 @@ public class GoogleDriveDownloadExecutor implements PluginNodeExecutor {
             String fileId = (String) input.get("fileId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/download/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/download/doc.md
@@ -22,4 +22,4 @@ Downloads a file from Google Drive and returns its content as a Base64 encoded s
 - `data` (string): Base64 encoded file content.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/download/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/download/schema.json
@@ -16,40 +16,23 @@
           "description": "ID of the file to download"
         }
       },
-      "required": ["profile", "fileId"],
+      "required": [
+        "profile",
+        "fileId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/get_metadata/GoogleDriveGetMetadataExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/get_metadata/GoogleDriveGetMetadataExecutor.java
@@ -43,8 +43,8 @@ public class GoogleDriveGetMetadataExecutor implements PluginNodeExecutor {
             String fileId = (String) input.get("fileId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/get_metadata/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/get_metadata/doc.md
@@ -19,4 +19,4 @@ Retrieves metadata for a single Google Drive file using the Google Drive API v3.
 - `file` (object): Metadata of the requested file.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/get_metadata/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/get_metadata/schema.json
@@ -16,40 +16,23 @@
           "description": "ID of the file to retrieve metadata for"
         }
       },
-      "required": ["profile", "fileId"],
+      "required": [
+        "profile",
+        "fileId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/list/GoogleDriveListExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/list/GoogleDriveListExecutor.java
@@ -43,8 +43,8 @@ public class GoogleDriveListExecutor implements PluginNodeExecutor {
             String query = (String) input.getOrDefault("query", "trashed=false");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/list/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/list/doc.md
@@ -32,21 +32,10 @@ Uses OAuth2 credentials to access Google Drive and retrieve basic file informati
 ```
 
 ## Credentials
-Create a secret profile group (e.g., `my-google-drive-profile`) that includes the following keys:
+Configure a plugin-level OAuth profile (e.g., `my-google-drive-profile`) with the following keys:
 
-```json
-{
-  "profiles": [
-    {
-      "name": "my-google-drive-profile",
-      "keys": {
-        "CLIENT_ID": "<client id>",
-        "CLIENT_SECRET": "<client secret>",
-        "REFRESH_TOKEN": "<refresh token>"
-      }
-    }
-  ]
-}
-```
+- `CLIENT_ID`
+- `CLIENT_SECRET`
+- `REFRESH_TOKEN`
 
-The profile name is supplied via the `profile` input field and the system resolves these keys to their secret values before execution.
+Reference the profile name via the `profile` input field. The system retrieves these keys from the plugin-level profile before execution.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/list/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/list/schema.json
@@ -17,43 +17,22 @@
           "default": "trashed=false"
         }
       },
-      "required": ["profile"],
+      "required": [
+        "profile"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Profile name referencing a stored secret group"
-          },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/move/GoogleDriveMoveExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/move/GoogleDriveMoveExecutor.java
@@ -46,8 +46,8 @@ public class GoogleDriveMoveExecutor implements PluginNodeExecutor {
             String sourceFolderId = (String) input.get("sourceFolderId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/move/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/move/doc.md
@@ -22,4 +22,4 @@ Moves an existing file to a different folder in Google Drive.
 - `parents` (array of strings): New parent folder IDs of the file.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/move/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/move/schema.json
@@ -24,40 +24,24 @@
           "description": "ID of the current parent folder; if omitted it will be looked up"
         }
       },
-      "required": ["profile", "fileId", "destinationFolderId"],
+      "required": [
+        "profile",
+        "fileId",
+        "destinationFolderId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/share/GoogleDriveShareExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/share/GoogleDriveShareExecutor.java
@@ -49,8 +49,8 @@ public class GoogleDriveShareExecutor implements PluginNodeExecutor {
             String emailAddress = (String) input.get("emailAddress");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/share/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/share/doc.md
@@ -22,4 +22,4 @@ Adds a permission to a file in Google Drive, allowing it to be shared with a use
 - `permission` (object): Permission resource created for the file.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/share/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/share/schema.json
@@ -28,40 +28,25 @@
           "description": "Email address of the user or group to share with"
         }
       },
-      "required": ["profile", "fileId", "role", "type"],
+      "required": [
+        "profile",
+        "fileId",
+        "role",
+        "type"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/trash/GoogleDriveTrashExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/trash/GoogleDriveTrashExecutor.java
@@ -43,8 +43,8 @@ public class GoogleDriveTrashExecutor implements PluginNodeExecutor {
             String fileId = (String) input.get("fileId");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/trash/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/trash/doc.md
@@ -19,4 +19,4 @@ Moves a file to the trash in Google Drive.
 - `file` (object): Updated file metadata including the `trashed` state.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/trash/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/trash/schema.json
@@ -16,40 +16,23 @@
           "description": "ID of the file to move to trash"
         }
       },
-      "required": ["profile", "fileId"],
+      "required": [
+        "profile",
+        "fileId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/update/GoogleDriveUpdateExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/update/GoogleDriveUpdateExecutor.java
@@ -52,8 +52,8 @@ public class GoogleDriveUpdateExecutor implements PluginNodeExecutor {
             String contentBase64 = (String) input.get("contentBase64");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/update/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/update/doc.md
@@ -23,4 +23,4 @@ Updates metadata or content of an existing file in Google Drive. Use this node t
 - `file` (object): Updated file resource returned from the API.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/update/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/update/schema.json
@@ -32,40 +32,23 @@
           "description": "Base64-encoded content to replace the file with"
         }
       },
-      "required": ["profile", "fileId"],
+      "required": [
+        "profile",
+        "fileId"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/upload/GoogleDriveUploadExecutor.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/upload/GoogleDriveUploadExecutor.java
@@ -47,8 +47,8 @@ public class GoogleDriveUploadExecutor implements PluginNodeExecutor {
             String data = (String) input.get("data");
 
             @SuppressWarnings("unchecked")
-            Map<String, Map<String, String>> secretMap = context.read("secrets", Map.class);
-            Map<String, String> credentials = secretMap.get(profile);
+            Map<String, Map<String, String>> profileMap = context.read("profiles", Map.class);
+            Map<String, String> credentials = profileMap.get(profile);
             String clientId = credentials.get("CLIENT_ID");
             String clientSecret = credentials.get("CLIENT_SECRET");
             String refreshToken = credentials.get("REFRESH_TOKEN");

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/upload/doc.md
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/upload/doc.md
@@ -21,4 +21,4 @@ Uploads a file to Google Drive from Base64 encoded data.
 - `file` (object): Metadata of the uploaded file.
 
 ## Credentials
-Use the same credential profile structure as the List Files node.
+Use the plugin-level OAuth profile referenced by the `profile` input field. Configure this profile once with `CLIENT_ID`, `CLIENT_SECRET`, and `REFRESH_TOKEN`.

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/upload/schema.json
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/files/upload/schema.json
@@ -25,40 +25,24 @@
           "description": "Base64 encoded file content"
         }
       },
-      "required": ["profile", "name", "data"],
+      "required": [
+        "profile",
+        "name",
+        "data"
+      ],
       "additionalProperties": false
     },
     "output": {
       "type": "object",
       "title": "Output Schema"
     },
-    "profiles": {
-      "type": "array",
-      "title": "Credential Profiles",
-      "description": "Secret groups with required Google OAuth keys",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "title": "Profile Definition",
-        "properties": {
-          "name": { "type": "string", "description": "Profile name referencing a stored secret group" },
-          "keys": {
-            "type": "object",
-            "description": "Required secret keys for this profile",
-            "properties": {
-              "CLIENT_ID": { "type": "string" },
-              "CLIENT_SECRET": { "type": "string" },
-              "REFRESH_TOKEN": { "type": "string" }
-            },
-            "required": ["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["name", "keys"],
-        "additionalProperties": false
-      }
+    "profile": {
+      "$ref": "plugin:profile"
     }
   },
-  "required": ["input", "output", "profiles"],
+  "required": [
+    "input",
+    "output"
+  ],
   "additionalProperties": false
 }

--- a/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/share/GoogleDriveServiceManager.java
+++ b/src/main/java/org/phong/zenflow/plugin/subdomain/nodes/builtin/integration/google/drive/share/GoogleDriveServiceManager.java
@@ -21,7 +21,9 @@ import java.util.List;
 /**
  * Resource manager for Google Drive {@link Drive} clients.
  * Uses the generic {@link BaseNodeResourceManager} infrastructure for
- * sharing Drive instances across nodes.
+ * sharing Drive instances across nodes. Credentials are sourced from
+ * the plugin-level OAuth profile referenced by each node's {@code profile}
+ * input.
  */
 @Slf4j
 @Component


### PR DESCRIPTION
## Summary
- deduplicate Google Drive/Docs node profile schemas by referencing the shared plugin profile
- document plugin-level credential profile usage across Google nodes
- clarify service managers use credentials from plugin profiles
- use execution-context profile map to resolve OAuth credentials across all Google Drive and Docs executors

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68c043be27c0832d8074e0b15dab4641